### PR TITLE
Improve resiliency when invoking DTE

### DIFF
--- a/src/Directory.props
+++ b/src/Directory.props
@@ -6,6 +6,9 @@
     <PackOnBuild>true</PackOnBuild>
     <PackageProjectUrl>https://clarius.org/SmallSharp</PackageProjectUrl>
     <NoWarn>NU1702;$(NoWarn)</NoWarn>
+
+    <StartAction>Program</StartAction>
+    <StartProgram>$(VsInstallRoot)\Common7\IDE\devenv.exe</StartProgram>
   </PropertyGroup>
 
 </Project>

--- a/src/SmallSharp.Build/OpenStartupFile.cs
+++ b/src/SmallSharp.Build/OpenStartupFile.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using EnvDTE;
+﻿using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -15,7 +13,7 @@ namespace SmallSharp.Build
 
         public override bool Execute()
         {
-            if (FlagFile == null || StartupFile == null)
+            if (string.IsNullOrEmpty(FlagFile) || string.IsNullOrEmpty(StartupFile))
                 return true;
 
             if (!File.Exists(FlagFile) ||
@@ -24,7 +22,7 @@ namespace SmallSharp.Build
                 // This defers the opening until the build completes.
                 BuildEngine4.RegisterTaskObject(
                     StartupFile,
-                    new DisposableAction(() => WindowsInterop.EnsureOpened(StartupFile)),
+                    new DisposableAction(() => WindowsInterop.EnsureOpened(StartupFile!)),
                     RegisteredTaskObjectLifetime.Build, false);
 
                 File.WriteAllText(FlagFile, StartupFile);

--- a/src/SmallSharp.Build/SmallSharp.Build.csproj
+++ b/src/SmallSharp.Build/SmallSharp.Build.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <PackFolder>build\netstandard2.0</PackFolder>
+    <PackNone>true</PackNone>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,6 +16,10 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="16.7.30328.74" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.0" Version="16.7.30328.74" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="SmallSharp.targets" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/src/SmallSharp.Build/SmallSharp.targets
+++ b/src/SmallSharp.Build/SmallSharp.targets
@@ -4,18 +4,12 @@
   <UsingTask AssemblyFile="SmallSharp.Build.dll" TaskName="OpenStartupFile" Condition="'$(BuildingInsideVisualStudio)' == 'true'" />
 
   <PropertyGroup>
-    <DefaultItemExcludesInProjectFolder>*$(DefaultLanguageSourceExtension)</DefaultItemExcludesInProjectFolder>
     <MSBuildShortVersion>$(MSBuildVersion.TrimEnd('0123456789').TrimEnd('.'))</MSBuildShortVersion>
     <UserProjectNamespace>
       <Namespace Prefix="msb" Uri="http://schemas.microsoft.com/developer/msbuild/2003" />
     </UserProjectNamespace>
     <StartupFile>$(ActiveDebugProfile)</StartupFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="*$(DefaultLanguageSourceExtension)" Exclude="$(ActiveDebugProfile)" />
-    <Compile Include="$(ActiveDebugProfile)" Condition="Exists('$(ActiveDebugProfile)')" />
-  </ItemGroup>
 
   <ItemGroup>
     <CompilerVisibleProperty Include="MSBuildProjectDirectory" />
@@ -27,10 +21,18 @@
   </ItemGroup>
 
   <!-- NOTE: we only require VS16.8+ when running in the IDE, since for CLI builds we just do targets stuff -->
-  <Target Name="EnsureVisualStudio" BeforeTargets="BeforeCompile;CoreCompile" 
+  <Target Name="EnsureVisualStudio" BeforeTargets="BeforeCompile;CoreCompile"
           Condition="$(MSBuildShortVersion) &lt; '16.8' and '$(BuildingInsideVisualStudio)' == 'true'">
     <!-- Top-level programs require this, so does our source generator. -->
     <Error Text="SmallSharp requires Visual Studio 16.8 or greater." />
+  </Target>
+
+  <Target Name="SelectTopLevelCompile" BeforeTargets="BeforeCompile;CoreCompile;CompileDesignTime" DependsOnTargets="SelectStartupFile">
+    <ItemGroup>
+      <None Include="*$(DefaultLanguageSourceExtension)" />
+      <Compile Remove="*$(DefaultLanguageSourceExtension)" />
+      <Compile Include="$(StartupFile)" Condition="Exists('$(StartupFile)')" />
+    </ItemGroup>
   </Target>
 
   <Target Name="SelectStartupFile" BeforeTargets="BeforeCompile;CoreCompile"
@@ -122,12 +124,9 @@
     <Warning Text="Could not set ActiveDebugProfile=$(StartupFile). Run the project once to fix it."
              Condition="'$(StartupFile)' != '' and '$(StartupDebugProfile)' != '$(StartupFile)'"/>
 
-    <ItemGroup>
-      <Compile Include="$(StartupFile)" Condition="'$(StartupFile)' != ''" />
-    </ItemGroup>
   </Target>
 
-  <Target Name="OpenStartupFile" 
+  <Target Name="OpenStartupFile"
           BeforeTargets="CompileDesignTime"
           DependsOnTargets="SelectStartupFile"
           Condition="'$(OpenStartupFile)' != 'false' and 
@@ -144,7 +143,7 @@
   <Target Name="MonitorActiveDocument" AfterTargets="CompileDesignTime">
     <MonitorActiveDocument FlagFile="$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(BaseIntermediateOutputPath)', 'OpenedStartupFile.txt'))"
                            LaunchProfiles="$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', 'Properties', 'launchSettings.json'))"
-                           UserFile="$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(MSBuildProjectFile).user'))" />  
+                           UserFile="$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(MSBuildProjectFile).user'))" />
   </Target>
 
   <!-- Adds the additional files that the source generator uses to emit the launch profiles. -->


### PR DESCRIPTION
Various minor improvements including:

* Not starting the active document monitoring until initial build completes
* Retrying opening of the startup file if ExecuteCommand fails (IDE might be busy doing something else on the UI thread)
* Not trying to open startup file if we can't determine which one
* Some troubleshooting aids by capturing thrown exceptions for Debug.Fail diagnostics

Fixes #18