### PR TITLE
Bump files with dotnet-file sync

### DIFF
--- a/.github/.github_changelog_generator
+++ b/.github/.github_changelog_generator
@@ -1,8 +1,7 @@
 usernames-as-github-logins=true
-header-label=
 issues_wo_labels=true
 pr_wo_labels=true
-exclude-labels=dependencies,duplicate,question,invalid,wontfix,need info
+exclude-labels=bydesign,dependencies,duplicate,question,invalid,wontfix,need info
 enhancement-label=:sparkles: Implemented enhancements:
 bugs-label=:bug: Fixed bugs:
 issues-label=:hammer: Other:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,15 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: ⚙ dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+
       - name: ✓ ensure format
         run: |
-          dotnet tool update -g dotnet-format --version 5.0.*
           dotnet restore
-          dotnet format --check -v:diag
+          dotnet format --verify-no-changes -v:diag
 
   build:
     name: build-${{ matrix.os }}
@@ -43,7 +47,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [windows-2022, ubuntu-latest, macOS-latest]
     steps:
       - name: 🤘 checkout
         uses: actions/checkout@v2
@@ -51,11 +55,23 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: ⚙ dotnet
+        uses: actions/setup-dotnet@v1
+        if: matrix.os != 'windows-2022'
+        with:
+          dotnet-version: '6.0.x'
+
       - name: 🙏 build
         run: dotnet build -m:1 -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"
 
+      - name: ⚙ GNU grep
+        if: matrix.os == 'macOS-latest'
+        run: |
+          brew install grep
+          echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> .bash_profile
+
       - name: 🧪 test
-        run: dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m
+        uses: ./.github/workflows/test
 
       - name: 📦 pack
         run: dotnet pack -m:1 -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,10 +24,15 @@ jobs:
           ref: main
           token: ${{ env.GH_TOKEN }}
 
-      - name: ⚙ changelog
-        uses: faberNovel/github-changelog-generator-action@master
+      - name: ⚙ ruby
+        uses: ruby/setup-ruby@v1
         with:
-          options: --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md
+          ruby-version: 3.0.3
+
+      - name: ⚙ changelog
+        run: |
+          gem install github_changelog_generator 
+          github_changelog_generator --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md --config-file .github/.github_changelog_generator
 
       - name: 🚀 changelog
         run: |

--- a/.github/workflows/dotnet-file.yml
+++ b/.github/workflows/dotnet-file.yml
@@ -53,7 +53,7 @@ jobs:
           branch: dotnet-file-sync
           delete-branch: true
           labels: dependencies
-          commit-message: Bump files with dotnet-file sync
+          commit-message: ⬆️ Bump files with dotnet-file sync
           
             ${{ env.CHANGES }}
           title: "Bump files with dotnet-file sync"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,9 +1,14 @@
 name: pages
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
       - pages
+
+env:
+  PAGES_ORGANIZATION: ${{ secrets.PAGES_ORGANIZATION }}
+  PAGES_REPOSITORY: ${{ secrets.PAGES_REPOSITORY }}
 
 jobs:
   gh-pages:
@@ -17,11 +22,20 @@ jobs:
           sudo gem install bundler
           bundle install
 
-      - name: 🖉 repo
-        run: echo "REPOSITORY=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
+      - name: 🖉 default env
+        env:
+          PAGES_ORGANIZATION: ${{ secrets.PAGES_ORGANIZATION }}
+          PAGES_REPOSITORY: ${{ secrets.PAGES_REPOSITORY }}
+        run: |
+          echo "PAGES_ORGANIZATION=${PAGES_ORGANIZATION}" >> $GITHUB_ENV
+          echo "PAGES_REPOSITORY=${PAGES_REPOSITORY}" >> $GITHUB_ENV
+
+      - name: 🖉 default repo
+        if: env.PAGES_REPOSITORY == ''
+        run: echo "PAGES_REPOSITORY=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
       - name: 🙏 build
-        run: bundle exec jekyll build -b ${{ env.REPOSITORY }}
+        run: bundle exec jekyll build -b ${{ env.PAGES_REPOSITORY }}
         env:
           JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -30,15 +44,15 @@ jobs:
           cd _site
           git init
           git add -A
-          git config --local user.email "hello@clarius.org"
-          git config --local user.name "GitHub Action"
+          git config --local user.email "bot@devlooped.com"
+          git config --local user.name "bot@devlooped.com"
           git commit -m "Publish pages from ${GITHUB_REPOSITORY}@${GITHUB_SHA:0:9}"
 
       - name: 🚀 push
         uses: ad-m/github-push-action@v0.6.0
         with:
-          github_token: ${{ secrets.CLARIUS_ACCESS_TOKEN }}
-          repository: clarius/${{ env.REPOSITORY }}
+          github_token: ${{ secrets.PAGES_ACCESS_TOKEN }}
+          repository: ${{ env.PAGES_ORGANIZATION }}/${{ env.PAGES_REPOSITORY }}
           branch: gh-pages
           force: true
           directory: ./_site

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,12 +20,23 @@ jobs:
         with: 
           submodules: recursive
           fetch-depth: 0
-          
+
+      - name: ⚙ dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+
       - name: 🙏 build
         run: dotnet build -m:1 -p:version=${GITHUB_REF#refs/*/v}
 
+      - name: ⚙ GNU grep
+        if: matrix.os == 'macOS-latest'
+        run: |
+          brew install grep
+          echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> .bash_profile
+
       - name: 🧪 test
-        run: dotnet test --no-build -m:1
+        uses: ./.github/workflows/test
 
       - name: 📦 pack
         run: dotnet pack -m:1 -p:version=${GITHUB_REF#refs/*/v}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -20,17 +20,22 @@ jobs:
       - name: 🏷 since
         run: echo "SINCE_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))" >> $GITHUB_ENV
 
-      - name: ⚙ changelog
-        uses: faberNovel/github-changelog-generator-action@master
-        if: env.SINCE_TAG != ''
+      - name: ⚙ ruby
+        uses: ruby/setup-ruby@v1
         with:
-          options: --token ${{ secrets.GITHUB_TOKEN }} --since-tag ${{ env.SINCE_TAG }} --o changelog.md
+          ruby-version: 3.0.3
 
       - name: ⚙ changelog
-        uses: faberNovel/github-changelog-generator-action@master
+        if: env.SINCE_TAG != ''
+        run: |
+          gem install github_changelog_generator 
+          github_changelog_generator --since-tag ${{ env.SINCE_TAG }} --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md --config-file .github/.github_changelog_generator
+
+      - name: ⚙ changelog
         if: env.SINCE_TAG == ''
-        with:
-          options: --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md
+        run: |
+          gem install github_changelog_generator 
+          github_changelog_generator --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md --config-file .github/.github_changelog_generator
 
       - name: 🖉 release
         shell: pwsh
@@ -42,7 +47,7 @@ jobs:
             ConvertFrom-Json | 
             select -ExpandProperty id
             
-          $notes = (Get-Content .\changelog.md | where { !($_ -like '\*') } | %{ $_.replace('\', '\\') }) -join '\n'
+          $notes = (Get-Content .\changelog.md | where { !($_ -like '\*') } | %{ $_.replace('\', '\\').replace('"', "'").replace('undefined', 'un-defined') }) -join '\n'
           $headers = @{ 'Accept'='application/vnd.github.v3+json;charset=utf-8'; 'Authorization' = "bearer $env:GITHUB_TOKEN" }
           $body = '{ "body":"' + $notes + '" }'
 

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -1,0 +1,34 @@
+name: test
+description: runs dotnet tests with retry
+runs:
+  using: "composite"
+  steps:
+    - name: 🧪 test
+      shell: bash --noprofile --norc {0}
+      env:
+        LC_ALL: en_US.utf8
+      run: |
+        [ -f .bash_profile ] && source .bash_profile
+        counter=0
+        exitcode=0
+        reset="\e[0m"
+        warn="\e[0;33m"
+        while [ $counter -lt 6 ]
+        do
+            if [ $filter ]
+            then
+                echo -e "${warn}Retry $counter for $filter ${reset}"
+            fi
+            # run test and forward output also to a file in addition to stdout (tee command)
+            dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m --filter=$filter | tee ./output.log
+            # capture dotnet test exit status, different from tee
+            exitcode=${PIPESTATUS[0]}
+            if [ $exitcode == 0 ]
+            then
+                exit 0
+            fi
+            # cat output, get failed test names, join as DisplayName=TEST with |, remove trailing |.
+            filter=$(cat ./output.log | grep -o -P '(?<=\sFailed\s)\w*' | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
+            ((counter++))
+        done
+        exit $exitcode

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin
 obj
 artifacts
 pack
+TestResults
 .vs
 .vscode
 
@@ -15,6 +16,8 @@ pack
 *.cache
 *.binlog
 *.zip
+__azurite*.*
+__*__
 
 .nuget
 *.lock.json

--- a/.netconfig
+++ b/.netconfig
@@ -40,37 +40,32 @@
 	sha = 0683ee777d7d878d4bf013d7deea352685135a05
 [file ".github/workflows/build.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/build.yml
-	etag = 91e9a208cd134bd7b71d7419800c613bc50a30e21e605607528721f2acdeab86
+	etag = 22c14ba80c39988ffd19c9b8737f541774cb75994004d432225ba4ff007f1403
 	weak
-	sha = fc5889d5387e2d5aa7aba279b2aa12251cf08cb2
+	sha = 7ebebbdbab67d9d895a29b3d2b3f82a62a7d8c4e
 [file ".github/workflows/changelog.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.yml
-	etag = 1e17c477f9e26f83367870a18e3727a71dcbb49cd31d85e0cfcfe092202d3a66
+	etag = 202803313c2792cb09d9cb8041fe4b39e550e26c90971a57b92534c599a596a7
 	weak
-	sha = 084aa7c36ee1c262ea2f9e83931068366a7b4312
+	sha = be8f625e4cf5c2c572c7e56ba6dc4c4935ab0c00
 [file ".github/workflows/publish.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/publish.yml
-	etag = ad8681ee3f191f796944135772b74565c470e349464e793aa664c888f7784b7a
+	etag = 242bd273906e0cbef773b5a0696f6dccf304d044a659b68e75ede5b1f5ea94fe
 	weak
-	sha = 55c0b32601e94e1eed35028a0cad510c6bcbb265
+	sha = 7ebebbdbab67d9d895a29b3d2b3f82a62a7d8c4e
 [file ".github/workflows/release-artifacts.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/release-artifacts.yml
     skip
 [file ".github/workflows/release-notes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/release-notes.yml
-	etag = c987e5b93b002c5a2a63304f677eb969b7b6e274b77ef4392aeef4d9ca7e10dd
+	etag = d1de9cb9c403ed8632d22d4cc153ae63b075266b9ce638b9ac73fd47dd2bccc1
 	weak
-	sha = 70bc909d2ce6924385a8bcc3a9fb1cff338a3fb7
-[file ".github_changelog_generator"]
-	url = https://github.com/devlooped/oss/blob/main/.github_changelog_generator
-	etag = 44dc852588ec508eaed9cefe260618eb162f0db50495188fc3c4e266b41944e2
-	weak
-	sha = a7ab5fe706fdfe1efb05d47d00ef4bb137088669
+	sha = be8f625e4cf5c2c572c7e56ba6dc4c4935ab0c00
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
-	etag = 925782b685859e07040442303b411bebd1c75b4fe4e075f547e067f33f323814
+	etag = 2b49512f81b6cb44c4ee398975c0edf41bfa4137857b59770805fa7c5e49e94b
 	weak
-	sha = fa83a5161ba52bc5d510ce0ba75ee0b1f8d4bc63
+	sha = 978c71c6afd095eaba35097fd7deed44fa09aa91
 [file "Directory.Build.rsp"]
 	url = https://github.com/devlooped/oss/blob/main/Directory.Build.rsp
 	etag = 6a6c6e1d3895df953abf14c82b0899e3eea75cdcd679f6212dcfea15183d73d6
@@ -83,9 +78,9 @@
 	sha = fa83a5161ba52bc5d510ce0ba75ee0b1f8d4bc63
 [file "assets/css/style.scss"]
 	url = https://github.com/devlooped/oss/blob/main/assets/css/style.scss
-	etag = 2c86a074a6c8c2f6af806908a57215439fad563830b4af8fbed1a3aabaede0cf
+	etag = f710d8919abfd5a8d00050b74ba7d0bb05c6d02e40842a3012eb96555c208504
 	weak
-	sha = b5583942b012f42f5ac2d06200427070cc18c250
+	sha = 9db26e2710b084d219d6355339d822f159bf5780
 [file "assets/images/sponsors.png"]
 	url = https://github.com/devlooped/oss/blob/main/assets/images/sponsors.png
 	etag = f152d1038eb04cb1596a13377b032f18f2402c969130601384fb377ce5ddefbd
@@ -113,14 +108,14 @@
 	sha = a0f58a6d63e48ae6e55944c556d0bc94476dc8df
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	etag = ae2606c157b9725ce8c707e30d9768fb0bad901ac34065d3cd75fc2bdbc5f8cf
+	etag = 819e24ed16c1257f3c6ea3c728e1507020bacf32aeb63f5dd56f9a5cb2652275
 	weak
-	sha = 52d6c40aaa460ac48fc74c03324c6b1db7ae170d
+	sha = 2fea462dc563923800a7efad24a52aa0541a8864
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	etag = 874f20853c983e6440ed67bb571d94927f9fb4cd4438585b07df7b420c664609
+	etag = 87c4dff4b44072c6825b451957af6d920616d77c50152a7d99719151c3d24639
 	weak
-	sha = 55c0b32601e94e1eed35028a0cad510c6bcbb265
+	sha = 4f57ffe1d48addf16641934e7b1e47ef70204e6e
 [file "src/kzu.snk"]
 	url = https://github.com/devlooped/oss/blob/main/src/kzu.snk
 	etag = b8d789b5b6bea017cdcc8badcea888ad78de3e34298efca922054e9fb0e7b6b9
@@ -133,9 +128,9 @@
 	sha = a0f58a6d63e48ae6e55944c556d0bc94476dc8df
 [file ".github/workflows/pages.yml"]
 	url = https://github.com/devlooped/.github/blob/main/.github/workflows/pages.yml
-	etag = f2bc91354dc634de00aa9f502eb69e34368c315bcdbe422cde95ddd850d31669
+	etag = 42fdc888e07b492cccc6fd29972bd9ea6f13691a3fdf057e07f3f8eec9330b7a
 	weak
-	sha = f2dc1370469bec1b2d32d82faf659b050cdc7e2a
+	sha = e8f3774884afda36ac177c4193929d24d7901de9
 [file ".github/workflows/sponsors.ps1"]
 	url = https://github.com/devlooped/.github/blob/main/.github/workflows/sponsors.ps1
 	etag = 57a303125f3367b68ad0700d89ff4ba57cb29b33b303903488c9c8638d0bf735
@@ -153,6 +148,21 @@
 	sha = f2dc1370469bec1b2d32d82faf659b050cdc7e2a
 [file ".github/workflows/dotnet-file.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file.yml
-	sha = 084aa7c36ee1c262ea2f9e83931068366a7b4312
-	etag = 501f8bf58287fdd7467701342f7251a015bc29664b494e7d81a71c0c55bee61f
+	sha = 2a39a426f66402e47c80818f92748a1bfd7d736c
+	etag = c424e4f9159bd5d4ccb3b65646a65eed5ad153f57111e3b56900ebce10194f3f
+	weak
+[file ".github/.github_changelog_generator"]
+	url = https://github.com/devlooped/oss/blob/main/.github/.github_changelog_generator
+	sha = b7ce2bedba3fe467b8bc252c372cd36bbde259a5
+	etag = 28145d505ce95b57628ab368bb12744300d5f539d3651c346e3c0c3f772ffa7b
+	weak
+[file ".github/workflows/test/action.yml"]
+	url = https://github.com/devlooped/oss/blob/main/.github/workflows/test/action.yml
+	sha = 3b9f317fc4f3edb926b26c4e4db9773a5f95ebca
+	etag = cf89aeff5c66fd3c0d0aaa655b527d66f5e823413c7a6788a62542e93d344576
+	weak
+[file "src/nuget.config"]
+	url = https://github.com/devlooped/oss/blob/main/src/nuget.config
+	sha = 7d0ccab53c166b87b971040f25de06570821f8ac
+	etag = 0ef58051c4db505e16b39954b27ab9e7a903647998b959e0924634d5f01824dd
 	weak

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -15,3 +15,12 @@ pre, code {
  code {
     font-size: 0.80em;
 }
+
+h1 > img {
+    border: unset;
+    box-shadow: unset;
+    vertical-align: middle;
+    -moz-box-shadow: unset;
+    -o-box-shadow: unset;
+    -ms-box-shadow: unset;
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,7 +23,13 @@
     <Copyright>Copyright (C) Daniel Cazzulino and Contributors. All rights reserved.</Copyright>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+
+    <!-- Pick src-level readme+icon automatically -->
     <PackageIcon Condition="Exists('$(MSBuildThisFileDirectory)icon.png')">icon.png</PackageIcon>
+    <PackageReadmeFile Condition="Exists('$(MSBuildThisFileDirectory)readme.md')">readme.md</PackageReadmeFile>
+    <!-- Pick project-level readme+icon overrides automatically -->
+    <PackageIcon Condition="Exists('$(MSBuildProjectDirectory)\icon.png')">icon.png</PackageIcon>
+    <PackageReadmeFile Condition="Exists('$(MSBuildProjectDirectory)\readme.md')">readme.md</PackageReadmeFile>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <GenerateRepositoryUrlAttribute>true</GenerateRepositoryUrlAttribute>
@@ -32,21 +38,16 @@
 
     <!-- Use Directory.Packages.props if possible. NOTE: other MSBuild SDKs (i.e. NoTargets/Traversal) do not support central packages -->
     <ManagePackageVersionsCentrally Condition="Exists('$(MSBuildThisFileDirectory)Directory.Packages.props') AND ('$(MSBuildProjectExtension)' == '.csproj' OR '$(MSBuildProjectExtension)' == '.vbproj')">true</ManagePackageVersionsCentrally>
-    <!-- Always add our my CI package feed first for easier dogfooding -->
-    <RestoreSources>https://pkg.kzu.io/index.json;https://api.nuget.org/v3/index.json;$(RestoreSources)</RestoreSources>
-  </PropertyGroup>
+    <RestoreSources>https://api.nuget.org/v3/index.json;https://pkg.kzu.io/index.json;$(RestoreSources)</RestoreSources>
 
-  <ItemGroup Label="NuGet">
-    <!-- This is compatible with nugetizer and SDK pack -->
-    <None Include="$(MSBuildThisFileDirectory)icon.png" Link="icon.png"
-          Pack="true"
-          Visible="false"
-          PackagePath="%(Filename)%(Extension)"
-          Condition="Exists('$(MSBuildThisFileDirectory)icon.png')" />
-  </ItemGroup>
+    <!-- Ensure MSBuild tooling can access package artifacts always via PKG_[PackageId] -->
+    <GeneratePathProperty>true</GeneratePathProperty>
+  </PropertyGroup>
 
   <PropertyGroup Label="Build">
     <Configuration Condition="'$(Configuration)' == '' and $(CI)">Release</Configuration>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GenerateDocumentationFile Condition="$(MSBuildProjectName.Contains('Tests'))">false</GenerateDocumentationFile>
     <LangVersion>Latest</LangVersion>
 
     <!-- See https://docs.microsoft.com/en-us/dotnet/standard/assembly/reference-assemblies -->
@@ -82,6 +83,9 @@
     
     <!-- Preserve transitively copied content in VS: https://github.com/dotnet/msbuild/issues/1054#issuecomment-847959047 -->
     <MSBuildCopyContentTransitively>true</MSBuildCopyContentTransitively>
+    
+    <!-- Global tools should run on whatever latest runtime is installed. See https://docs.microsoft.com/en-us/dotnet/core/versions/selection#framework-dependent-apps-roll-forward -->
+    <RollForward>LatestMinor</RollForward>
   </PropertyGroup>
 
   <PropertyGroup Label="StrongName" Condition="Exists('$(MSBuildThisFileDirectory)kzu.snk')">
@@ -126,6 +130,8 @@
   </PropertyGroup>
 
   <ItemGroup Label="ThisAssembly.Project">
+    <ProjectProperty Include="CI" />
+  
     <ProjectProperty Include="Version" />
     <ProjectProperty Include="VersionPrefix" />
     <ProjectProperty Include="VersionSuffix" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -6,6 +6,11 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(IsPackable)' == ''">
+    <IsPackable Condition="'$(PackAsTool)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(PackFolder)' != ''">true</IsPackable>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(IsPackable)' == ''">
     <!-- The Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets unconditionally sets 
         PackageId=AssemblyName if no PackageId is provided, and then defaults IsPackable=true if 
         a PackageId is set (?!), meaning that by default everything is packable in Sdk-style 
@@ -19,6 +24,28 @@
     <IsPackable Condition="'$(PackageId)' == ''">false</IsPackable>
     <IsPackable Condition="'$(PackageId)' != ''">true</IsPackable>
   </PropertyGroup>
+  
+  <ItemGroup Condition="'$(IsPackable)' == 'true'" Label="NuGet">
+    <!-- This is compatible with nugetizer and SDK pack -->
+
+    <!-- Project-level icon/readme will already be part of None items -->
+    <None Update="@(None -> WithMetadataValue('Filename', 'icon'))" 
+          Pack="true" PackagePath="%(Filename)%(Extension)" 
+          Condition="'$(PackageIcon)' != ''" />
+
+    <None Update="@(None -> WithMetadataValue('Filename', 'readme'))" 
+          Pack="true" PackagePath="%(Filename)%(Extension)" 
+          Condition="'$(PackageReadmeFile)' != ''" />
+    
+    <!-- src-level will need explicit inclusion -->
+    <None Include="$(MSBuildThisFileDirectory)icon.png" Link="icon.png" Visible="false" 
+          Pack="true" PackagePath="%(Filename)%(Extension)"
+          Condition="Exists('$(MSBuildThisFileDirectory)icon.png') and !Exists('$(MSBuildProjectDirectory)icon.png')" />
+
+    <None Include="$(MSBuildThisFileDirectory)readme.md" Link="readme.md"  
+          Pack="true" PackagePath="%(Filename)%(Extension)"
+          Condition="Exists('$(MSBuildThisFileDirectory)readme.md') and !Exists('$(MSBuildProjectDirectory)readme.md')" />
+  </ItemGroup>
 
   <!-- Microsoft.NET.Sdk\targets\Microsoft.NET.DefaultAssemblyInfo.targets does this and is imported 
        before Directory.Build.targets, but it's not imported for .msbuildproj -->
@@ -82,8 +109,11 @@
 
   <ItemGroup>
     <!-- Make these available via ThisAssembly.Project -->
+    <ProjectProperty Include="RepositoryBranch" />
     <ProjectProperty Include="RepositorySha" />
     <ProjectProperty Include="RepositoryCommit" />
+    <ProjectProperty Include="RepositoryRoot" />
+    <ProjectProperty Include="RepositoryUrl" />
   </ItemGroup>
 
   <!-- Make sure the source control info is available before calling source generators -->
@@ -102,6 +132,15 @@
       <RepositorySha Condition="'$(RepositorySha)' == ''">$(SourceRevisionId.Substring(0, 9))</RepositorySha>
       <!-- This allows the commit label added to the InformationalVersion to be the short sha instead :) -->
       <SourceRevisionId>$(RepositorySha)</SourceRevisionId>
+    </PropertyGroup>
+
+    <!-- Add SourceRoot as a project property too -->
+    <ItemGroup>
+      <_GitSourceRoot Include="@(SourceRoot -> WithMetadataValue('SourceControl', 'git'))" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <RepositoryRoot>@(_GitSourceRoot)</RepositoryRoot>
     </PropertyGroup>
 
   </Target>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <config>
+      <add key="signatureValidationMode" value="accept" />
+    </config>
+    <trustedSigners>
+      <author name="Microsoft">
+        <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint="AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+      </author>
+      <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
+        <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint="5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint=" CF7AC17AD047ECD5FDC36822031B12D4EF078B6F2B4C5E6BA41F8FF2CF4BAD67" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint="C474CE76007D02394E0DA5E4DE7C14C680F9E282013CFEF653EF5DB71FDF61F8" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+      </repository>
+    </trustedSigners>
+</configuration>


### PR DESCRIPTION
# devlooped/oss

- Move changelog config to .github, switch to gem https://github.com/devlooped/oss/commit/b7ce2be
- Reuse test with retries definition by using a composite action https://github.com/devlooped/oss/commit/3b9f317
- Avoid nuget errors for nuget repository signature validation https://github.com/devlooped/oss/commit/7d0ccab
- Automatically retry failed tests up to 5 times https://github.com/devlooped/oss/commit/8bc16a7
- Ensure GNU grep is used on macOS https://github.com/devlooped/oss/commit/964caa3
- Now that .NET6 is LTS, ensure it's installed https://github.com/devlooped/oss/commit/7ebebbd
- Escape double quotes from changelog https://github.com/devlooped/oss/commit/2b73cb3
- Replace double quotes with single quotes https://github.com/devlooped/oss/commit/0cbe576
- Replace 'undefined' JSON keyword https://github.com/devlooped/oss/commit/b07aaab
- Ensure ruby v3 is installed for changelog generation https://github.com/devlooped/oss/commit/be8f625
- Ignore TestResults folders https://github.com/devlooped/oss/commit/a9f9d3f
- Ignore azurite files https://github.com/devlooped/oss/commit/829faad
- Add azurite hidden folders too https://github.com/devlooped/oss/commit/978c71c
- Improve default rendering of header icon https://github.com/devlooped/oss/commit/9db26e2
- Generate API documentation for non-tests projects by default https://github.com/devlooped/oss/commit/32213f2
- Add nuget.org as first restore source, for convenience https://github.com/devlooped/oss/commit/3f294a1
- Automatically set/include icon.png and readme.md https://github.com/devlooped/oss/commit/e260665
- Global tools should run on whatever latest runtime is installed. https://github.com/devlooped/oss/commit/b65c8f1
- Ensure MSBuild tooling can access package artifacts always via PKG_[PackageId] https://github.com/devlooped/oss/commit/cc6922f
- Add CI as a project property https://github.com/devlooped/oss/commit/2fea462
- If PackAsTool=true, default IsPackable=true, for obvious reasons https://github.com/devlooped/oss/commit/fde1f6f
- If PackFolder is specified, assume IsPackable=true https://github.com/devlooped/oss/commit/b0249cf
- Make src-level readme visible for easier editing https://github.com/devlooped/oss/commit/bfe0f2a
- Add RepositoryBranch as a ThisAssembly.Project property https://github.com/devlooped/oss/commit/83d7378
- Add RepositoryRoot property from source control information https://github.com/devlooped/oss/commit/f9763d3
- Add RepositoryUrl as project property, if available https://github.com/devlooped/oss/commit/4f57ffe
- Add icon prefix to match dependabot https://github.com/devlooped/oss/commit/2a39a42

# devlooped/.github

- Allow overriding target pages org https://github.com/devlooped/.github/commit/8f41377
- Improve overriding and defaulting for token too https://github.com/devlooped/.github/commit/245ad41
- Allow running pages workflow manually https://github.com/devlooped/.github/commit/4234724
- Pages access token should always come from secrets https://github.com/devlooped/.github/commit/e8f3774