### PR TITLE
Fix issue with properties containing spaces

### DIFF
--- a/src/SmallSharp/EmitTargets.cs
+++ b/src/SmallSharp/EmitTargets.cs
@@ -11,7 +11,7 @@ namespace SmallSharp;
 public class EmitTargets : Task
 {
     static readonly Regex packageExpr = new(@"^#:package\s+([^@]+)@(.+)$");
-    static readonly Regex propertyExpr = new(@"^#:property\s+([^@]+)\s+(.+)$");
+    static readonly Regex propertyExpr = new(@"^#:property\s+([^\s]+)\s+(.+)$");
 
     [Required]
     public ITaskItem? StartupFile { get; set; }


### PR DESCRIPTION
The regex was wrong and didn't match until the first whitespace for the property name.