### PR TITLE
Add support for #:sdk directive and no restore failures

### DIFF
--- a/src/SmallSharp/Sdk.Empty.props
+++ b/src/SmallSharp/Sdk.Empty.props
@@ -1,0 +1,3 @@
+<Project>
+  <!-- This is needed since the Microsoft.NET.SDK Sdk.props imports the Microsoft.Common.props unconditionally -->
+</Project>

--- a/src/SmallSharp/Sdk.props
+++ b/src/SmallSharp/Sdk.props
@@ -1,14 +1,25 @@
 <Project>
 
-  <Import Project="..\build\SmallSharp.props" />
-
   <PropertyGroup>
     <ImportProjectExtensionProps>true</ImportProjectExtensionProps>
     <ImportProjectExtensionTargets>true</ImportProjectExtensionTargets>
+    
+    <!-- Since we use this to build StartupFile list and as an SDK, we might not have .NET SDK imported yet (i.e. no C# files at all) -->
+    <UsingSmallSharpSDK>true</UsingSmallSharpSDK>
+
+    <!-- Workaround https://github.com/dotnet/sdk/issues/50573 -->
+    <AlternateCommonProps>$(MSBuildThisFileDirectory)\Sdk.Empty.props</AlternateCommonProps>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="JsonPoke" Version="1.2.0" PrivateAssets="all" />
-  </ItemGroup>
+  <!-- Import Common.props explicitly we're too early here to use MSBuildProjectExtensionsPath -->
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="'$(MicrosoftCommonPropsHasBeenImported)' != 'true' and Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.SDK"
+       Condition="!Exists('$(MSBuildProjectExtensionsPath)SmallSharp.sdks.props')" />
+
+  <Import Project="$(MSBuildProjectExtensionsPath)SmallSharp.sdks.props" 
+       Condition="Exists('$(MSBuildProjectExtensionsPath)SmallSharp.sdks.props')" />
+
+  <Import Project="..\build\SmallSharp.props" />
 
 </Project>

--- a/src/SmallSharp/Sdk.targets
+++ b/src/SmallSharp/Sdk.targets
@@ -1,5 +1,33 @@
 <Project>
 
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.SDK"
+       Condition="!Exists('$(MSBuildProjectExtensionsPath)SmallSharp.sdks.targets')" />
+
+  <Import Project="$(MSBuildProjectExtensionsPath)SmallSharp.sdks.targets"
+       Condition="Exists('$(MSBuildProjectExtensionsPath)SmallSharp.sdks.targets')" />
+
   <Import Project="..\build\SmallSharp.targets" />
+
+  <Target Name="ImplicitPackageReferenceFromStartupFile" BeforeTargets="_GenerateProjectRestoreGraphPerFramework"
+          DependsOnTargets="StartupFile"
+          Condition="'$(StartupFile)' != '' and Exists('$(StartupFile)') and '$(RestoreNeeded)' == 'true'" >
+
+    <!-- Optimize for restore success on first run without previously running our targets -->
+    <ReadLinesFromFile File="$(StartupFile)">
+      <Output TaskParameter="Lines" ItemName="_StartupFileLines" />
+    </ReadLinesFromFile>
+
+    <ItemGroup>
+      <_PkgLines Include="@(_StartupFileLines)"
+                 Condition="$([MSBuild]::ValueOrDefault('%(Identity)', '').StartsWith('#:package '))" />
+
+      <_PkgReference Include="$([MSBuild]::ValueOrDefault('%(_PkgLines.Identity)', '').Substring(10))" />
+
+      <PackageReference Condition="'@(_PkgReference)' != ''" Include="$([MSBuild]::ValueOrDefault('%(_PkgReference.Identity)', '').Split('@')[0])">
+        <Version>$([MSBuild]::ValueOrDefault('%(_PkgReference.Identity)', '').Split('@')[1])</Version>
+      </PackageReference>
+    </ItemGroup>
+
+  </Target>
 
 </Project>

--- a/src/SmallSharp/SmallSharp.csproj
+++ b/src/SmallSharp/SmallSharp.csproj
@@ -24,20 +24,26 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="1.3.0" />
-    <PackageReference Include="JsonPoke" Version="1.2.0" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.13.26" Pack="false" />
+    <PackageReference Include="NuGetizer" Version="1.3.0" />
+    <PackageReference Include="JsonPoke" Version="1.2.0" Pack="false" GeneratePathProperty="true" />
+    <PackageReference Include="NuGet.Versioning" Version="6.14.0" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly.Project" Version="2.0.14" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="..\_._" PackFolder="lib\netstandard2.0" Visible="false" />
     <None Update="SmallSharp.targets" PackFolder="$(PackFolder)" CopyToOutputDirectory="PreserveNewest" />
     <None Update="SmallSharp.Before.targets" PackFolder="$(PackFolder)" CopyToOutputDirectory="PreserveNewest" />
-    <None Update="Sdk.props;Sdk.targets" PackFolder="Sdk" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="Sdk.*" PackFolder="Sdk" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(PkgJsonPoke)\build\JsonPoke.dll" PackFolder="$(PackFolder)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+    <None Include="$(PkgJsonPoke)\build\Newtonsoft.Json.dll" PackFolder="$(PackFolder)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>
-    <UpToDateCheckInput Include="SmallSharp.targets;SmallSharp.Before.targets;Sdk.props;Sdk.targets" />
+    <UpToDateCheckInput Include="SmallSharp.targets;SmallSharp.Before.targets;Sdk.props;Sdk.Empty.props;Sdk.targets" />
+    <ProjectProperty Include="PackageVersion" />
   </ItemGroup>
 
 </Project>

--- a/src/SmallSharp/SmallSharp.props
+++ b/src/SmallSharp/SmallSharp.props
@@ -6,6 +6,8 @@
 
     <!-- Capture project-level properties before they are defaulted by Microsoft.Common.targets -->
     <CustomBeforeMicrosoftCSharpTargets>$(MSBuildThisFileDirectory)\SmallSharp.Before.props</CustomBeforeMicrosoftCSharpTargets>
-</PropertyGroup>
+
+    <UsingSmallSharpSDK Condition="'$(UsingSmallSharpSDK)' == ''">false</UsingSmallSharpSDK>
+  </PropertyGroup>
 
 </Project>

--- a/src/SmallSharp/SmallSharp.targets
+++ b/src/SmallSharp/SmallSharp.targets
@@ -1,38 +1,46 @@
 <Project>
 
   <UsingTask AssemblyFile="SmallSharp.dll" TaskName="EmitTargets" />
+  <UsingTask AssemblyFile="JsonPoke.dll" TaskName="JsonPoke"/>
 
   <PropertyGroup>
     <UserProjectNamespace>
       <Namespace Prefix="msb" Uri="http://schemas.microsoft.com/developer/msbuild/2003" />
     </UserProjectNamespace>
-    <StartupFile>$(ActiveDebugProfile)</StartupFile>
-    <StartupFile Condition="'$(ActiveDebugProfile)' == '' or !Exists('$(ActiveDebugProfile)')">$(ActiveCompile)</StartupFile>
-    <StartupFileDependsOn>EnsureImportProjectExtensions;CollectStartupFile;SelectStartupFile;SelectTopLevelCompile;UpdateLaunchSettings;EmitTargets</StartupFileDependsOn>
+    <!-- Backs compat -->
+    <ActiveFile Condition="'$(ActiveCompile)' != ''">$(ActiveCompile)</ActiveFile>
+    <StartupFile>$(ActiveFile)</StartupFile>
+    <StartupFile Condition="'$(StartupFile)' == ''">$(ActiveDebugProfile)</StartupFile>
+    <FindStartupFile Condition="'$(StartupFile)' == '' or !Exists('$(StartupFile)')">true</FindStartupFile>
+    <StartupFileDependsOn>EnsureProperties;CollectStartupFile;SelectStartupFile;SelectTopLevelCompile;UpdateLaunchSettings;EmitTargets</StartupFileDependsOn>
     
-    <!-- For CLI dotnet run, users should set ImportProjectExtensionTargets=true -->
+    <!-- For CLI dotnet run, users must set ImportProjectExtensionProps/ImportProjectExtensionTargets=true -->
+    <SmallSharpPackagesProps>$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).smallsharp.props</SmallSharpPackagesProps>
     <SmallSharpPackagesTargets>$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).smallsharp.targets</SmallSharpPackagesTargets>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- Ensures all top-level files show up in the IDE -->
-    <None Include="*$(DefaultLanguageSourceExtension)" Exclude="$(ActiveDebugProfile);$(ActiveCompile)" />
+    <None Include="*$(DefaultLanguageSourceExtension)" Exclude="$(ActiveDebugProfile);$(ActiveFile)" />
     <Compile Remove="*$(DefaultLanguageSourceExtension)" />
     <!-- Ensure changes we make to this file trigger a new DTB -->
     <UpToDateCheckBuilt Include="Properties\launchSettings.json" />
-    <UpToDateCheckBuilt Include="$(SmallSharpPackagesTargets)" />
+    <UpToDateCheckBuilt Include="$(SmallSharpPackagesProps);$(SmallSharpPackagesTargets)" />
   </ItemGroup>
 
   <!-- When restoring, if we include the source files, we'd get duplicate references. -->
   <ItemGroup Condition="'$(MSBuildIsRestoring)' != 'true'">
     <Compile Include="$(ActiveDebugProfile)" Condition="Exists('$(ActiveDebugProfile)')" />
-    <Compile Include="$(ActiveCompile)" Condition="Exists('$(ActiveCompile)') and '$(ActiveCompile)' != '$(ActiveDebugProfile)'" />
+    <Compile Include="$(ActiveFile)" Condition="Exists('$(ActiveFile)') and '$(ActiveFile)' != '$(ActiveDebugProfile)'" />
   </ItemGroup>
 
-  <Target Name="StartupFile" BeforeTargets="BeforeCompile;CoreCompile;CompileDesignTime;CollectUpToDateCheckInputDesignTime" DependsOnTargets="$(StartupFileDependsOn)" />
+  <Target Name="StartupFile" BeforeTargets="ResolvePackageAssets;CompileDesignTime;CollectUpToDateCheckInputDesignTime" DependsOnTargets="$(StartupFileDependsOn)" />
 
-  <Target Name="EnsureImportProjectExtensions" Condition="'$(_ImportProjectExtensionProps)' != 'true' or '$(_ImportProjectExtensionTargets)' != 'true'">
-    <Error Code="SCS01" Text="Setting ImportProjectExtensionProps and ImportProjectExtensionTargets project properties to 'true' is required by SmallSharp to support C# package and project directives." />
+  <Target Name="EnsureProperties" Condition="'$(CheckSmallSharpRequirements)' != 'false'">
+    <Error Code="SCS01" Condition="'$(_ImportProjectExtensionProps)' != 'true' or '$(_ImportProjectExtensionTargets)' != 'true'"
+           Text="Setting ImportProjectExtensionProps and ImportProjectExtensionTargets project properties to 'true' is required by SmallSharp to support C# package and project directives." />
+    <Error Code="SCS02" Condition="'$(ManagePackageVersionsCentrally)' == 'true'" 
+           Text="Setting ManagePackageVersionsCentrally to 'true' is not supported by SmallSharp since C# program files can declare package references via #:package directives." />
   </Target>
 
   <Target Name="CollectStartupFile">
@@ -41,27 +49,13 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="SelectTopLevelCompile">
-    <ItemGroup>
-      <!-- We remove all top-level from Compile because copy/pasting startup files may end up 
-           causing those items to be hardcoded in the .csproj -->
-      <Compile Remove="@(Compile -> WithMetadataValue('RelativeDir', ''))" />
-      <Compile Include="$(StartupFile)" Condition="'$(StartupFile)' != '' and Exists('$(StartupFile)')" />
-      <UpToDateCheckInput Include="$(StartupFile)" Condition="'$(StartupFile)' != '' and Exists('$(StartupFile)')" />
-    </ItemGroup>
-  </Target>
-
   <!-- Defaults the startup file to the first Compile, if none previously selected. -->
-  <Target Name="SelectStartupFile"
-          Condition="'$(StartupFile)' == '' or !Exists('$(StartupFile)')" Returns="$(StartupFile)">
+  <Target Name="SelectStartupFile" Condition="'$(FindStartupFile)' == 'true'" Returns="$(StartupFile)">
 
-    <PropertyGroup Condition="'$(ActiveDebugProfile)' == '' or !Exists('$(ActiveDebugProfile)')">
-      <FindStartupFile>true</FindStartupFile>
-    </PropertyGroup>
-    <ItemGroup Condition="'$(FindStartupFile)' == 'true'">
+    <ItemGroup>
       <ReversedCompile Include="@(StartupFile -> Reverse())" />
     </ItemGroup>
-    <PropertyGroup Condition="'$(FindStartupFile)' == 'true'">
+    <PropertyGroup>
       <StartupFile>%(ReversedCompile.Identity)</StartupFile>
     </PropertyGroup>
 
@@ -142,6 +136,16 @@
 
   </Target>
 
+  <Target Name="SelectTopLevelCompile">
+    <ItemGroup>
+      <!-- We remove all top-level from Compile because copy/pasting startup files may end up 
+           causing those items to be hardcoded in the .csproj -->
+      <Compile Remove="@(Compile -> WithMetadataValue('RelativeDir', ''))" />
+      <Compile Include="$(StartupFile)" Condition="'$(StartupFile)' != '' and Exists('$(StartupFile)')" />
+      <UpToDateCheckInput Include="$(StartupFile)" Condition="'$(StartupFile)' != '' and Exists('$(StartupFile)')" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="AfterClean">
     <Delete Files="$(MSBuildProjectDirectory)\Properties\launchSettings.json"
             Condition="Exists('$(MSBuildProjectDirectory)\Properties\launchSettings.json')" />
@@ -159,12 +163,41 @@
               Value="Project" />
   </Target>
 
-  <Target Name="EmitTargets" Returns="@(FileBasedPackage)"
-          DependsOnTargets="CollectStartupFile;SelectTopLevelCompile;SelectStartupFile" 
-          Inputs="@(Compile);$(ActiveDebugProfile);$(ActiveCompile);Properties\launchSettings.json" Outputs="Directory.Packages.props">
-    <EmitTargets StartupFile="$(StartupFile)" TargetsFile="$(SmallSharpPackagesTargets)">
+  <Target Name="EmitTargets" DependsOnTargets="CollectStartupFile;SelectTopLevelCompile;SelectStartupFile" 
+          Inputs="@(Compile);$(ActiveDebugProfile);$(ActiveFile);Properties\launchSettings.json" 
+          Outputs="$(SmallSharpPackagesProps);$(SmallSharpPackagesTargets)">
+    <EmitTargets StartupFile="$(StartupFile)"
+                 PropsFile="$(SmallSharpPackagesProps)"
+                 TargetsFile="$(SmallSharpPackagesTargets)"
+                 UsingSmallSharpSDK="$(UsingSmallSharpSDK)"
+                 BaseIntermediateOutputPath="$(BaseIntermediateOutputPath)">
       <Output TaskParameter="Packages" ItemName="FileBasedPackage" />
+      <Output TaskParameter="Properties" PropertyName="FileBasedProperty" />
+      <Output TaskParameter="Sdks" PropertyName="FileBasedSdk" />
+      <Output TaskParameter="Success" PropertyName="RestoreNeeded" />
     </EmitTargets>
+  </Target>
+
+  <Target Name="RestoreBeforeBuild" BeforeTargets="ResolvePackageAssets" DependsOnTargets="EmitTargets" 
+          Condition="'$(RestoreNeeded)' == 'true' and '$(DesignTimeBuild)' != 'true' and '$(UsingSmallSharpSDK)' != 'true'">
+
+    <PropertyGroup>
+      <DynamicProjectAssetsFile>$(MSBuildProjectExtensionsPath)smallsharp.assets.json</DynamicProjectAssetsFile>
+    </PropertyGroup>
+
+    <MSBuild
+        Projects="$(MSBuildProjectFullPath)"
+        Targets="Restore"
+        BuildInParallel="false"
+        Properties="RestoreUseStaticGraphEvaluation=false;ImportProjectExtensionProps=true;ImportProjectExtensionTargets=true;Guid=$([System.Guid]::NewGuid().ToString())">
+    </MSBuild>
+
+    <Copy SourceFiles="$(ProjectAssetsFile)" DestinationFiles="$(DynamicProjectAssetsFile)" />
+
+    <PropertyGroup>
+      <ProjectAssetsFile>$(DynamicProjectAssetsFile)</ProjectAssetsFile>
+    </PropertyGroup>
+
   </Target>
 
   <UsingTask TaskName="SortItems" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">


### PR DESCRIPTION
The SDK mode allows us to support the #:sdk directive such that our SDK imports the generated .sdk.props and .sdk.targets files. It can also set the required `ImportProjectExtension*` properties for automatically importing the targets during restore (if present in the base intermediate output path).

Even with the added properties, the situation on initial clone/run of a project using SmallSharp was suboptimal:
- whether in SDK mode or package mode, we'd need a second restore after the initial one and first EmitTargets run. VS does this automatically since it would detect the addition of new extension targets (due to the ImportProjectExtension* props) and restore again as needed. But it wouldn't work from the CLI
- this meant a dotnet build would fail consistently

So we have a dual mechanism that makes this seamless:
- In SDK mode we can optimize things by just parsing the startup/active file and injecting the package references before the restore graph is generated
- In package mode, we re-run restore and temporarily redirect the assets file to a different dynamic one to refresh the resolved assets.

Fixes #143