### PR TITLE
We only ever support C#, so use .cs extension

### DIFF
--- a/src/SmallSharp/SmallSharp.props
+++ b/src/SmallSharp/SmallSharp.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- This disables compilation error in VS for #: prefix -->
-    <Features Condition="'$(MSBuildIsRestoring)' != 'true'">$(Features);FileBasedProgram</Features>
+    <Features>$(Features);FileBasedProgram</Features>
 
     <!-- Capture project-level properties before they are defaulted by Microsoft.Common.targets -->
     <CustomBeforeMicrosoftCSharpTargets>$(MSBuildThisFileDirectory)\SmallSharp.Before.props</CustomBeforeMicrosoftCSharpTargets>

--- a/src/SmallSharp/SmallSharp.targets
+++ b/src/SmallSharp/SmallSharp.targets
@@ -21,8 +21,8 @@
 
   <ItemGroup>
     <!-- Ensures all top-level files show up in the IDE -->
-    <None Include="*$(DefaultLanguageSourceExtension)" Exclude="$(ActiveDebugProfile);$(ActiveFile)" />
-    <Compile Remove="*$(DefaultLanguageSourceExtension)" />
+    <None Include="*.cs" Exclude="$(ActiveDebugProfile);$(ActiveFile)" />
+    <Compile Remove="*.cs" />
     <!-- Ensure changes we make to this file trigger a new DTB -->
     <UpToDateCheckBuilt Include="Properties\launchSettings.json" />
     <UpToDateCheckBuilt Include="$(SmallSharpPackagesProps);$(SmallSharpPackagesTargets)" />
@@ -47,7 +47,7 @@
 
   <Target Name="CollectStartupFile">
     <ItemGroup>
-      <StartupFile Include="*$(DefaultLanguageSourceExtension)" />
+      <StartupFile Include="*.cs" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Don't rely on the property being set to (potentially) something else that we don't support