### PR TITLE
Align #:property Name=Value with RC syntax

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,8 +34,8 @@ specified per file:
 
 ```csharp
 #:package Humanizer@2.14.1
-#:property ImplicitUsings true
-#:property Nullable enable
+#:property ImplicitUsings=true
+#:property Nullable=enable
 
 using Humanizer;
 

--- a/src/Demo/Humanizer.cs
+++ b/src/Demo/Humanizer.cs
@@ -1,5 +1,5 @@
-﻿#:property ImplicitUsings true
-#:property Nullable enable
+﻿#:property ImplicitUsings=true
+#:property Nullable=enable
 #:package Humanizer@2.14.1
 
 using Humanizer;

--- a/src/Demo/Mcp.cs
+++ b/src/Demo/Mcp.cs
@@ -1,5 +1,5 @@
-#:property Title LaTeX to Image MCP
-#:property Version 0.5.0
+#:property Title=LaTeX to Image MCP
+#:property Version=0.5.0
 #:package Smith@0.2.5
 #:package DotNetConfig.Configuration@1.2.*
 #:package ModelContextProtocol@0.3.0-preview.*

--- a/src/SmallSharp/EmitTargets.cs
+++ b/src/SmallSharp/EmitTargets.cs
@@ -15,7 +15,7 @@ public class EmitTargets : Task
 {
     static readonly Regex sdkExpr = new(@"^#:sdk\s+([^@]+?)(@(.+))?$");
     static readonly Regex packageExpr = new(@"^#:package\s+([^@]+)@(.+)$");
-    static readonly Regex propertyExpr = new(@"^#:property\s+([^\s]+)\s+(.+)$");
+    static readonly Regex propertyExpr = new(@"^#:property\s+([^=]+)=(.+)$");
 
     [Required]
     public required ITaskItem StartupFile { get; set; }


### PR DESCRIPTION
The final version is with an = sign. See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives