### PR TITLE
Don't warn during restore about duplicate package refs

### DIFF
--- a/src/SmallSharp/Sdk.props
+++ b/src/SmallSharp/Sdk.props
@@ -9,6 +9,9 @@
 
     <!-- Workaround https://github.com/dotnet/sdk/issues/50573 -->
     <AlternateCommonProps>$(MSBuildThisFileDirectory)\Sdk.Empty.props</AlternateCommonProps>
+
+    <!-- Since we emit duplicate package references from SDK as well as .props -->
+    <NoWarn>$(NoWarn);NU1504</NoWarn>
   </PropertyGroup>
 
   <!-- Import Common.props explicitly we're too early here to use MSBuildProjectExtensionsPath -->


### PR DESCRIPTION
Added `<NoWarn>` property to suppress NU1504 warnings caused by duplicate package references emitted by the SDK and `.props`  files.