### PR TITLE
Switch to $(Start) to select startup file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,8 +129,10 @@ selecting the desired file from the Start button dropdown.
 When running from the command-line, you can select the file to run by passing it as an argument to `dotnet run`:
 
 ```bash
-dotnet run -p:ActiveFile program1.cs
+dotnet run -p:start=program1.cs
 ```
+
+You can also use the shortcut `-p:s=[FILE]`.
 
 ## How It Works
 

--- a/src/SmallSharp/SmallSharp.props
+++ b/src/SmallSharp/SmallSharp.props
@@ -7,7 +7,7 @@
     <!-- Capture project-level properties before they are defaulted by Microsoft.Common.targets -->
     <CustomBeforeMicrosoftCSharpTargets>$(MSBuildThisFileDirectory)\SmallSharp.Before.props</CustomBeforeMicrosoftCSharpTargets>
 
-    <UsingSmallSharpSDK Condition="'$(UsingSmallSharpSDK)' == ''">false</UsingSmallSharpSDK>
+    <UsingSmallSharpSDK Condition="'$(UsingSmallSharpSDK)' == ''">false</UsingSmallSharpSDK>    
   </PropertyGroup>
 
   <Import Project="SmallSharp.Version.props"/>

--- a/src/SmallSharp/SmallSharp.targets
+++ b/src/SmallSharp/SmallSharp.targets
@@ -10,6 +10,8 @@
     <!-- Backs compat -->
     <ActiveFile Condition="'$(ActiveCompile)' != ''">$(ActiveCompile)</ActiveFile>
     <StartupFile>$(ActiveFile)</StartupFile>
+    <StartupFile Condition="'$(StartupFile)' == ''">$(Start)</StartupFile>
+    <StartupFile Condition="'$(StartupFile)' == ''">$(S)</StartupFile>
     <StartupFile Condition="'$(StartupFile)' == ''">$(ActiveDebugProfile)</StartupFile>
     <FindStartupFile Condition="'$(StartupFile)' == '' or !Exists('$(StartupFile)')">true</FindStartupFile>
     <StartupFileDependsOn>EnsureProperties;CollectStartupFile;SelectStartupFile;SelectTopLevelCompile;UpdateLaunchSettings;EmitTargets</StartupFileDependsOn>

--- a/src/demo.ps1
+++ b/src/demo.ps1
@@ -7,7 +7,7 @@ jq --arg version "$version" '.["msbuild-sdks"].SmallSharp = $version' global.jso
 # build with each top-level file as the active one
 foreach ($file in gci *.cs) {
     # rm -r -fo obj -ea 0
-    dotnet build Demo.csproj -p:ActiveFile=$($file.Name) -bl:"$($file.BaseName).binlog"
+    dotnet build Demo.csproj -p:start=$($file.Name) -bl:"$($file.BaseName).binlog"
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Build failed for $($file.Name)"
         popd; popd;


### PR DESCRIPTION
Much shorter than the legacy ActiveCompile or the renamed ActiveFile. Just Start or even S works now.