### PR TITLE
Ensure when running from VS, output supports UTF-8

### DIFF
--- a/src/Demo/Hello.cs
+++ b/src/Demo/Hello.cs
@@ -1,3 +1,6 @@
 #:property ImplicitUsings=true
+#:package Spectre.Console@0.51.*
 
-Console.WriteLine("Hello, World!");
+using Spectre.Console;
+
+AnsiConsole.MarkupLine(":globe_showing_americas: Hello, World!");

--- a/src/SmallSharp/ConsoleEncodingInitializer.cs
+++ b/src/SmallSharp/ConsoleEncodingInitializer.cs
@@ -1,0 +1,24 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace System;
+
+/// <summary>
+/// Ensures that when running from Visual Studio on Windows, the console encoding is set to UTF-8 
+/// to support full Unicode and emoji output.
+/// </summary>
+class ConsoleEncodingInitializer
+{
+#pragma warning disable CA2255 // The 'ModuleInitializer' attribute should not be used in libraries
+    [ModuleInitializer]
+#pragma warning restore CA2255 // The 'ModuleInitializer' attribute should not be used in libraries
+    public static void Init()
+    {
+
+#if DEBUG
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            Console.InputEncoding = Console.OutputEncoding = Encoding.UTF8;
+#endif
+    }
+}

--- a/src/SmallSharp/Sdk.props
+++ b/src/SmallSharp/Sdk.props
@@ -25,4 +25,9 @@
 
   <Import Project="..\build\SmallSharp.props" />
 
+  <!-- In SDK mode, we don't get the content files like we do in package mode, so we add it explicitly here -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)..\contentFiles\cs\netstandard2.0\ConsoleEncodingInitializer.cs" 
+             NuGetPackageId="SmallSharp" />
+  </ItemGroup>
 </Project>

--- a/src/SmallSharp/SmallSharp.csproj
+++ b/src/SmallSharp/SmallSharp.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <None Include="..\..\osmfeula.txt" Link="osmfeula.txt" PackagePath="OSMFEULA.txt" />
+    <Compile Update="ConsoleEncodingInitializer.cs" Pack="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SmallSharp/SmallSharp.targets
+++ b/src/SmallSharp/SmallSharp.targets
@@ -28,6 +28,7 @@
     <!-- Ensure changes we make to this file trigger a new DTB -->
     <UpToDateCheckBuilt Include="Properties\launchSettings.json" />
     <UpToDateCheckBuilt Include="$(SmallSharpPackagesProps);$(SmallSharpPackagesTargets)" />
+    <Compile Update="@(Compile -> WithMetadataValue('NuGetPackageId', 'SmallSharp'))" Visible="false" />
   </ItemGroup>
 
   <!-- When restoring, if we include the source files, we'd get duplicate references. -->


### PR DESCRIPTION
Ensure when running from VS, output supports UTF-8

The console started by VS (even if it's the terminal one) by default does not seem to be set up to support UTF-8. To be on the conservative side, we just set up the encoding in DEBUG builds so things Just Work from VS by default.

This problem doesn't exist when running from a regular terminal.