### PR TITLE
Support central package version management

### DIFF
--- a/src/SmallSharp/EmitTargets.cs
+++ b/src/SmallSharp/EmitTargets.cs
@@ -14,7 +14,7 @@ namespace SmallSharp;
 public class EmitTargets : Task
 {
     static readonly Regex sdkExpr = new(@"^#:sdk\s+(?<sdk>[^@]+?)(@(?<version>.+))?$");
-    static readonly Regex packageExpr = new(@"^#:package\s+(?<id>[^@]+)@(?<version>.+)$");
+    static readonly Regex packageExpr = new(@"^#:package\s+(?<id>[^@\s]+)(@(?<version>.+))?$");
     static readonly Regex propertyExpr = new(@"^#:property\s+(?<name>[^=]+)=(?<value>.+)$");
 
     [Required]
@@ -31,6 +31,8 @@ public class EmitTargets : Task
 
     [Required]
     public required bool UsingSDK { get; set; }
+
+    public bool ManagePackageVersionsCentrally { get; set; }
 
     public ITaskItem[] PackageReferences { get; set; } = [];
 
@@ -62,18 +64,44 @@ public class EmitTargets : Task
         var properties = new List<XElement>();
         var sdks = new List<XAttribute[]>();
 
-        foreach (var line in contents)
+        for (var i = 0; i < contents.Length; i++)
         {
+            var line = contents[i];
             if (packageExpr.Match(line) is { Success: true } match)
             {
                 var id = match.Groups["id"].Value.Trim();
                 var version = match.Groups["version"].Value.Trim();
+                var hasVersion = !string.IsNullOrEmpty(version);
 
-                packages.Add(NewTaskItem(id, [("Version", version)]));
+                if (ManagePackageVersionsCentrally && hasVersion && !UsingSDK)
+                {
+                    Log.LogWarning(
+                        null,
+                        "SCS05",
+                        null,
+                        filePath,
+                        i + 1,
+                        0,
+                        0,
+                        0,
+                        "Package reference '{0}' declares version '{1}' via #:package while ManagePackageVersionsCentrally=true; SmallSharp will omit Version metadata and use the central package version.",
+                        id,
+                        version);
+                }
 
-                items.Add(new XElement("PackageReference",
-                    new XAttribute("Include", id),
-                    new XAttribute("Version", version)));
+                if (!ManagePackageVersionsCentrally && hasVersion)
+                {
+                    packages.Add(NewTaskItem(id, [("Version", version)]));
+                    items.Add(new XElement("PackageReference",
+                        new XAttribute("Include", id),
+                        new XAttribute("Version", version)));
+                }
+                else
+                {
+                    packages.Add(new TaskItem(id));
+                    items.Add(new XElement("PackageReference",
+                        new XAttribute("Include", id)));
+                }
             }
             else if (sdkExpr.Match(line) is { Success: true } sdkMatch)
             {
@@ -130,7 +158,7 @@ public class EmitTargets : Task
             new XElement("PropertyGroup",
                 [new XElement("SmallSharpProjectExtensionPropsImported", "true")])));
 
-        // Determine if a restore is needed: if any discovered #:package (id+version) is not already
+        // Determine if a restore is needed: if any discovered #:package is not already
         // present in the incoming PackageReferences list.
         foreach (var pkg in packages)
         {
@@ -138,7 +166,8 @@ public class EmitTargets : Task
             var version = pkg.GetMetadata("Version");
             var exists = PackageReferences?.Any(r =>
                 string.Equals(r.ItemSpec, id, StringComparison.OrdinalIgnoreCase) &&
-                string.Equals(r.GetMetadata("Version"), version, StringComparison.OrdinalIgnoreCase)) == true;
+                (string.IsNullOrEmpty(version) ||
+                 string.Equals(r.GetMetadata("Version"), version, StringComparison.OrdinalIgnoreCase))) == true;
 
             if (!exists)
             {

--- a/src/SmallSharp/Sdk.targets
+++ b/src/SmallSharp/Sdk.targets
@@ -26,10 +26,29 @@
     <ItemGroup Condition="'@(_PkgLines)' != ''">
       <_PkgReference Include="$([MSBuild]::ValueOrDefault('%(_PkgLines.Identity)', '').Substring(10))" />
 
-      <PackageReference Condition="'@(_PkgReference)' != ''" Include="$([MSBuild]::ValueOrDefault('%(_PkgReference.Identity)', '').Split('@')[0])">
-        <Version>$([MSBuild]::ValueOrDefault('%(_PkgReference.Identity)', '').Split('@')[1])</Version>
+      <_PkgReferenceWithVersion Include="@(_PkgReference)"
+                                Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(_PkgReference.Identity)', '@'))">
+        <PackageId>$([System.Text.RegularExpressions.Regex]::Replace('%(_PkgReference.Identity)', '@.*$', ''))</PackageId>
+        <PackageVersion>$([System.Text.RegularExpressions.Regex]::Replace('%(_PkgReference.Identity)', '^[^@]+@', ''))</PackageVersion>
+      </_PkgReferenceWithVersion>
+
+      <_PkgReferenceWithoutVersion Include="@(_PkgReference)"
+                                   Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('%(_PkgReference.Identity)', '@'))" />
+
+      <PackageReference Include="@(_PkgReferenceWithoutVersion)" />
+
+      <PackageReference Include="%(_PkgReferenceWithVersion.PackageId)"
+                        Condition="'$(ManagePackageVersionsCentrally)' == 'true'" />
+
+      <PackageReference Include="%(_PkgReferenceWithVersion.PackageId)"
+                        Condition="'$(ManagePackageVersionsCentrally)' != 'true'">
+        <Version>%(_PkgReferenceWithVersion.PackageVersion)</Version>
       </PackageReference>
     </ItemGroup>
+
+    <Warning Code="SCS05"
+             Condition="'$(ManagePackageVersionsCentrally)' == 'true' and '@(_PkgReferenceWithVersion)' != ''"
+             Text="Package references declared with #:package and @ versions are not compatible with ManagePackageVersionsCentrally=true; SmallSharp will omit Version metadata and use central package versions for: @(_PkgReferenceWithVersion -> '%(Identity)', ', ')." />
 
   </Target>
 

--- a/src/SmallSharp/SmallSharp.targets
+++ b/src/SmallSharp/SmallSharp.targets
@@ -51,8 +51,6 @@
   <Target Name="EnsureProperties" Condition="'$(CheckSmallSharpRequirements)' != 'false'">
     <Error Code="SCS02" Condition="'$(_ImportProjectExtensionProps)' != 'true' or '$(_ImportProjectExtensionTargets)' != 'true'"
            Text="Setting ImportProjectExtensionProps and ImportProjectExtensionTargets project properties to 'true' is required by SmallSharp to support C# package and project directives." />
-    <Error Code="SCS03" Condition="'$(ManagePackageVersionsCentrally)' == 'true'" 
-           Text="Setting ManagePackageVersionsCentrally to 'true' is not supported by SmallSharp since C# program files can declare package references via #:package directives." />
     <Warning Code="SCS04" Condition="'$(UsingSmallSharpSDK)' != 'true'"
              Text='For maximum compatibility with file-based apps, use SmallSharp as an SDK instead of a package reference: &lt;Project Sdk="SmallSharp/$(SmallSharpVersion)"&gt;' />
   </Target>
@@ -195,11 +193,12 @@
           Inputs="@(Compile);$(ActiveDebugProfile);$(ActiveFile);Properties\launchSettings.json" 
           Outputs="$(SmallSharpPackagesProps);$(SmallSharpPackagesTargets)">
     <EmitTargets StartupFile="$(StartupFile)" 
-                 UsingSDK="$(UsingSmallSharpSDK)"
-                 PackageReferences="@(PackageReferences)"
-                 PropsFile="$(SmallSharpPackagesProps)"
-                 TargetsFile="$(SmallSharpPackagesTargets)"
-                 BaseIntermediateOutputPath="$(BaseIntermediateOutputPath)">
+                  UsingSDK="$(UsingSmallSharpSDK)"
+                  ManagePackageVersionsCentrally="$([MSBuild]::ValueOrDefault('$(ManagePackageVersionsCentrally)', 'false'))"
+                  PackageReferences="@(PackageReferences)"
+                  PropsFile="$(SmallSharpPackagesProps)"
+                  TargetsFile="$(SmallSharpPackagesTargets)"
+                  BaseIntermediateOutputPath="$(BaseIntermediateOutputPath)">
       <Output TaskParameter="Packages" ItemName="FileBasedPackage" />
       <Output TaskParameter="Properties" PropertyName="FileBasedProperty" />
       <Output TaskParameter="Sdks" PropertyName="FileBasedSdk" />


### PR DESCRIPTION
Support central package version management

Allow SmallSharp package directives to work when ManagePackageVersionsCentrally is enabled by omitting Version metadata for centrally managed package references and warning when inline versions are present.