### PR TITLE
Add default project launch profile

### DIFF
--- a/src/SmallSharp/SmallSharp.targets
+++ b/src/SmallSharp/SmallSharp.targets
@@ -195,6 +195,9 @@
       <Output TaskParameter="SortedItems" ItemName="SortedStartupFile" />
     </SortItems>
     <JsonPoke ContentPath="$(MSBuildProjectDirectory)\Properties\launchSettings.json"
+              Query="$.profiles['$(MSBuildProjectName)'].commandName"
+              Value="$(MSBuildProjectName)" />
+    <JsonPoke ContentPath="$(MSBuildProjectDirectory)\Properties\launchSettings.json"
               Query="$.profiles['%(SortedStartupFile.Filename)%(SortedStartupFile.Extension)'].commandName"
               Value="Project" />
   </Target>


### PR DESCRIPTION
Ensure generated launchSettings.json includes Visual Studio's default project-named profile alongside SmallSharp file profiles.