### PR TITLE
Use Project for default launch profile command name

### DIFF
--- a/src/SmallSharp/SmallSharp.targets
+++ b/src/SmallSharp/SmallSharp.targets
@@ -196,7 +196,7 @@
     </SortItems>
     <JsonPoke ContentPath="$(MSBuildProjectDirectory)\Properties\launchSettings.json"
               Query="$.profiles['$(MSBuildProjectName)'].commandName"
-              Value="$(MSBuildProjectName)" />
+              Value="Project" />
     <JsonPoke ContentPath="$(MSBuildProjectDirectory)\Properties\launchSettings.json"
               Query="$.profiles['%(SortedStartupFile.Filename)%(SortedStartupFile.Extension)'].commandName"
               Value="Project" />


### PR DESCRIPTION
Ensure the project-name entry written to Properties\\launchSettings.json uses the fixed commandName value expected by launch profiles instead of the MSBuild project name.

