### PR TITLE
Fix target inconsistency in generated SDK targets

### DIFF
--- a/src/SmallSharp/Sdk.props
+++ b/src/SmallSharp/Sdk.props
@@ -18,10 +18,10 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="'$(MicrosoftCommonPropsHasBeenImported)' != 'true' and Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk"
-       Condition="!Exists('$(MSBuildProjectExtensionsPath)SmallSharp.sdks.props')" />
+       Condition="!Exists('$(MSBuildProjectExtensionsPath)SmallSharp.sdk.props')" />
 
-  <Import Project="$(MSBuildProjectExtensionsPath)SmallSharp.sdks.props" 
-       Condition="Exists('$(MSBuildProjectExtensionsPath)SmallSharp.sdks.props')" />
+  <Import Project="$(MSBuildProjectExtensionsPath)SmallSharp.sdk.props" 
+       Condition="Exists('$(MSBuildProjectExtensionsPath)SmallSharp.sdk.props')" />
 
   <Import Project="..\build\SmallSharp.props" />
 

--- a/src/SmallSharp/Sdk.targets
+++ b/src/SmallSharp/Sdk.targets
@@ -1,10 +1,10 @@
 <Project>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk"
-       Condition="!Exists('$(MSBuildProjectExtensionsPath)SmallSharp.sdks.targets')" />
+       Condition="!Exists('$(MSBuildProjectExtensionsPath)SmallSharp.sdk.targets')" />
 
-  <Import Project="$(MSBuildProjectExtensionsPath)SmallSharp.sdks.targets"
-       Condition="Exists('$(MSBuildProjectExtensionsPath)SmallSharp.sdks.targets')" />
+  <Import Project="$(MSBuildProjectExtensionsPath)SmallSharp.sdk.targets"
+       Condition="Exists('$(MSBuildProjectExtensionsPath)SmallSharp.sdk.targets')" />
 
   <Import Project="..\build\SmallSharp.targets" />
 


### PR DESCRIPTION
This was causing the SDKs to not be properly imported when specified as `#:sdk ...` in the C# file.